### PR TITLE
Craft 4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.0 - 2023-06-26
+### Updated
+- Craft 4 compatibility
+
 ## 2.0.0 - 2018-11-07
 ### Added
 - Craft 3 compatibility

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-This plugin requires Craft CMS 3.0.0-beta.23 or later.
+This plugin requires Craft CMS 4.0.0 or later.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "viget/craft-lever",
     "description": "Wrapper to integrate with the Lever API",
     "type": "craft-plugin",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "keywords": [
         "craft",
         "cms",
@@ -22,7 +22,8 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0-RC1"
+        "craftcms/cms": "^4.0.0",
+        "php": "^8.0.2"
     },
     "autoload": {
         "psr-4": {
@@ -39,5 +40,16 @@
             "leverService": "viget\\lever\\services\\LeverService"
         },
         "class": "viget\\lever\\Lever"
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true,
+            "craftcms/plugin-installer": true
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require-dev": {
+        "craftcms/rector": "dev-main"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,5 @@
             "yiisoft/yii2-composer": true,
             "craftcms/plugin-installer": true
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "require-dev": {
-        "craftcms/rector": "dev-main"
     }
 }

--- a/src/Lever.php
+++ b/src/Lever.php
@@ -33,7 +33,7 @@ use yii\base\Event;
  *
  * @property  LeverServiceService $leverService
  */
-class Lever extends Plugin
+class Lever extends \craft\base\Plugin
 {
     // Static Properties
     // =========================================================================
@@ -42,14 +42,6 @@ class Lever extends Plugin
      * @var Lever
      */
     public static $plugin;
-
-    // Public Properties
-    // =========================================================================
-
-    /**
-     * @var string
-     */
-    public $schemaVersion = '2.0.0';
 
     // Public Methods
     // =========================================================================
@@ -91,7 +83,7 @@ class Lever extends Plugin
     // Protected Methods
     // =========================================================================
 
-    protected function createSettingsModel()
+    protected function createSettingsModel(): ?\craft\base\Model
     {
         return new \viget\lever\models\Settings();
     }

--- a/src/Lever.php
+++ b/src/Lever.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lever plugin for Craft CMS 3.x
+ * Lever plugin for Craft CMS 4.x
  *
  * Wrapper to integrate with the Lever API
  *

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -31,7 +31,7 @@ class DefaultController extends Controller
      *         The actions must be in 'kebab-case'
      * @access protected
      */
-    protected $allowAnonymous = ['save-applicant'];
+    protected array|int|bool $allowAnonymous = ['save-applicant'];
 
     // Public Methods
     // =========================================================================

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lever plugin for Craft CMS 3.x
+ * Lever plugin for Craft CMS 4.x
  *
  * Wrapper to integrate with the Lever API
  *

--- a/src/fields/LeverField.php
+++ b/src/fields/LeverField.php
@@ -43,7 +43,7 @@ class LeverField extends Field
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
     }
@@ -59,7 +59,7 @@ class LeverField extends Field
     /**
      * @inheritdoc
      */
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         if (empty($value)) return NULL;
         if (is_array($value)) return $value;
@@ -77,7 +77,7 @@ class LeverField extends Field
     /**
      * @inheritdoc
      */
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return parent::serializeValue($value, $element);
     }
@@ -85,7 +85,7 @@ class LeverField extends Field
     /**
      * @inheritdoc
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         // Get our id and namespace
         $id = Craft::$app->getView()->formatInputId($this->handle);

--- a/src/fields/LeverField.php
+++ b/src/fields/LeverField.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lever plugin for Craft CMS 3.x
+ * Lever plugin for Craft CMS 4.x
  *
  * Wrapper to integrate with the Lever API
  *

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -9,7 +9,7 @@ class Settings extends Model
     public $apiKey = '';
     public $site = '';
 
-    public function rules()
+    public function rules(): array
     {
         return [
             [['apiKey', 'site'], 'required'],

--- a/src/services/LeverService.php
+++ b/src/services/LeverService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lever plugin for Craft CMS 3.x
+ * Lever plugin for Craft CMS 4.x
  *
  * Wrapper to integrate with the Lever API
  *

--- a/src/templates/_components/fields/LeverField_input.twig
+++ b/src/templates/_components/fields/LeverField_input.twig
@@ -16,8 +16,10 @@
 
 {% set selections = [] %}
 {% if values %}
-    {% for value in values if value.leverId is defined %}
-        {% set selections = selections | merge([value.leverId]) %}
+    {% for value in values %}
+        {% if value.leverId is defined %}
+            {% set selections = selections | merge([value.leverId]) %}
+        {% endif %}
     {% endfor %}
 {% endif %}
 

--- a/src/templates/_components/fields/LeverField_input.twig
+++ b/src/templates/_components/fields/LeverField_input.twig
@@ -1,6 +1,6 @@
 {#
 /**
- * Lever plugin for Craft CMS 3.x
+ * Lever plugin for Craft CMS 4.x
  *
  * LeverField Field Input
  *

--- a/src/translations/en/lever.php
+++ b/src/translations/en/lever.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lever plugin for Craft CMS 3.x
+ * Lever plugin for Craft CMS 4.x
  *
  * Wrapper to integrate with the Lever API
  *


### PR DESCRIPTION
Updates plugin to work with Craft 4.

How the plugin was upgraded:
- Ran Rector with `RemoveMethodCallParam` disabled because it was throwing an error.
- Uploaded Rector changes into this branch.
- Required plugin with this branch in a Craft 4 project via `"viget/craft-lever": "dev-jdf\/craft-4"`.
- Tracked down additional errors until everything worked as expected.